### PR TITLE
Update PowerSync icon and URL

### DIFF
--- a/_data/content.json
+++ b/_data/content.json
@@ -319,8 +319,8 @@
           {
             "title": "PowerSync",
             "author": "JourneyApps",
-            "url": "https://www.powersync.co",
-            "icon": "https://journeyapps.com/assets/images/powersync-hexasync-icon-001.png"
+            "url": "https://www.powersync.com",
+            "icon": "https://journeyapps.com/assets/images/powersync-logo-icon.png"
           },
           {
             "title": "Replicache",


### PR DESCRIPTION
Update PowerSync icon to new version recently shipped: https://x.com/powersync_/status/1796545161909936506

Update PowerSync URL which has changed from powersync.co to powersync.com