### PR TITLE
Add Trust1Connector local IDP

### DIFF
--- a/_data/content.json
+++ b/_data/content.json
@@ -254,6 +254,17 @@
         ]
       },
       {
+        "title": "Identity and Authentication Management",
+        "items": [
+          {
+            "title": "Trust1Connector",
+            "author": "Michallis Pashidis",
+            "url": "https://rmc.t1t.io",
+            "icon": "https://i.imgur.com/uOr2AvA.png"
+          }
+        ]
+      },
+      {
         "title": "Syncing data",
         "items": [
           {


### PR DESCRIPTION
Trust1Connector is a middleware for smart-card communcation, mobile wallets and verifiable claims, running local-first. The local-first vision was already enforced at the start of the product in 2014. The cloud is used for synchronization and connectivity is optional.