### PR TITLE
Add SignalDB

### DIFF
--- a/_data/content.json
+++ b/_data/content.json
@@ -216,6 +216,12 @@
             "icon": "https://rxdb.info/files/logo/logo.svg"
           },
           {
+            "title": "SignalDB",
+            "author": "Max Nowack",
+            "url": "https://signaldb.js.org",
+            "icon": "https://signaldb.js.org/logo.svg"
+          },
+          {
             "title": "Socket Runtime",
             "author": "Socket Runtime Team",
             "url": "https://github.com/socketsupply/socket",


### PR DESCRIPTION
SignalDB is a in-memory database with signal-based reactivity across multiple frameworks. It also offers persistence and sync options.