### PR TITLE
Adding a local AI solution

### DIFF
--- a/_data/content.json
+++ b/_data/content.json
@@ -433,6 +433,17 @@
         ]
       },
       {
+        "title": "Analyzing data",
+        "items": [
+          {
+            "title": "ao_core: locally learning AI models",
+            "author": "AO Labs",
+            "url": "https://www.aolabs.ai/",
+            "icon": "https://i.imgur.com/0PaP7fr.png"
+          }
+        ]
+      },
+      {
         "title": "Examples",
         "items": [
           {


### PR DESCRIPTION
Adding a new subsection for "Analyzing data" under "Build," for ao_core, an AI package that uses weightless NNs for local training/inference.

We're increasingly applying our AI to local use-cases, like this device discovery agent for NetBox: https://github.com/aolabsai/netbox

https://www.aolabs.ai/
AO Labs is building a more reliable alternative to deep learning and LLMs using continuously trainable, compute-efficient weightless neural networks. We are building AI that can learn after training.

Thank you!