### PR TITLE
Add Couchbase Capella

### DIFF
--- a/_data/content.json
+++ b/_data/content.json
@@ -429,6 +429,12 @@
             "author": "Jay Meistrich",
             "url": "https://github.com/LegendApp/legend-state",
             "icon": "https://avatars.githubusercontent.com/u/60373862?s=192&v=4"
+          },
+          {
+            "title": "Couchbase Capella",
+            "author": "Couchbase Inc",
+            "url": "https://www.couchbase.com/products/capella",
+            "icon": "https://www.couchbase.com/wp-content/uploads/2024/04/Capella-Logo-1.svg"
           }
         ]
       },


### PR DESCRIPTION
Couhbase capella app services provides local first db with sync to couchbase.
Also a nice replacement for the deprecated Mongodb Atlas SDKs/Realm.